### PR TITLE
Refactor: Improved audio data handling and processing.

### DIFF
--- a/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/AudioRecordModel.kt
+++ b/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/AudioRecordModel.kt
@@ -1,5 +1,8 @@
 package com.eka.voice2rx_sdk
 
+import androidx.annotation.Keep
+
+@Keep
 data class AudioRecordModel(
     val frameData: ShortArray,
     val isSilence: Boolean,

--- a/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/UploadService.kt
+++ b/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/UploadService.kt
@@ -35,22 +35,16 @@ internal class UploadService(
                 val clipIndex = currentClipIndex
                 val lastClipIndex = lastClipIndex1
                 if (clipIndex == -1) {
-//                    return@launch
                 } else {
                     clippedAudioData.addAll(
                         audioData.subList(lastClipIndex + 1, clipIndex + 1).map { it.frameData })
-                    var startTimeStamp = audioData.first().timeStamp
-                    if (lastClipIndex > 0) {
-                        startTimeStamp = audioData[lastClipIndex - 1].timeStamp
-                    }
-                    val endTimeStamp = audioData[clipIndex - 1].timeStamp
+
                     generateAudioFileFromAudioData(
-                        clippedAudioData,
-                        getCombinedAudio(clippedAudioData),
-                        startTimeStamp,
-                        endTimeStamp
+                        audioData = getCombinedAudio(clippedAudioData),
+                        startIndex = lastClipIndex,
+                        endIndex = clipIndex
                     )
-                    audioHelper.removeData(0, clipIndex)
+                    audioHelper.removeData()
                 }
             } catch (e: Exception) {
                 VoiceLogger.d(TAG, e.printStackTrace().toString())
@@ -72,10 +66,9 @@ internal class UploadService(
     }
 
     fun generateAudioFileFromAudioData(
-        audioDataList: List<ShortArray>,
         audioData: ShortArray,
-        start: Long,
-        end: Long
+        startIndex: Int,
+        endIndex: Int
     ) {
         if(audioData.size < 16000) {
             return
@@ -85,7 +78,11 @@ internal class UploadService(
         val wavFileName = "${sessionId + "_" + FILE_INDEX}.wav"
         val outputFile = File(context.filesDir, fileName)
 
-        audioHelper.onNewFileCreated(fileName, end, start)
+        audioHelper.onNewFileCreated(
+            fileName = fileName,
+            endTime = audioHelper.getClipTimeFromClipIndex(endIndex),
+            startTime = audioHelper.getClipTimeFromClipIndex(startIndex)
+        )
         audioCombiner.writeWavFile(
             context,
             inputFile = File(context.filesDir, wavFileName),

--- a/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/data/remote/services/AwsS3UploadService.kt
+++ b/voice2rx_sdk/src/main/java/com/eka/voice2rx_sdk/data/remote/services/AwsS3UploadService.kt
@@ -163,7 +163,7 @@ object AwsS3UploadService {
         withContext(Dispatchers.IO) {
             val sessions = repository?.getAllSessions()
             sessions?.forEach {
-                if (it.transcript == null || it.structuredRx == null) {
+                if (!it.isProcessed) {
                     readAndUpdateSession(it)
                 }
             }
@@ -182,7 +182,7 @@ object AwsS3UploadService {
             val isStructuredRxExist =
                 checkFileExists(Voice2RxInternalUtils.BUCKET_NAME, structuredRxPath)
 
-            if (!isStructuredRxExist || !isTranscriptExist) {
+            if (!isStructuredRxExist && !isTranscriptExist) {
                 return@withContext
             }
 


### PR DESCRIPTION
- Added `@Keep` annotation to `AudioRecordModel`.
- Modified `AwsS3UploadService` to check for unprocessed sessions using `isProcessed` flag.
- Modified `AwsS3UploadService` to proceed if both structured Rx and transcript do not exist.
- Set `bucketName` to `Voice2RxInternalUtils.BUCKET_NAME`.
- Removed unnecessary `onAudio` call comment in `V2RxInternal`.
- Modified `audioHelper` initialization in `V2RxInternal` to include sample rate, frame size, and cut durations from `Voice2Rx` configuration.
- Added synchronization to `audioRecordData` in `AudioHelper`.
- Modified `AudioHelper` to receive sample rate and frame size.
- Modified `AudioHelper` to calculate samples passed more accurately.
- Added `getClipTimeFromClipIndex` function in `AudioHelper`.
- Modified `AudioHelper` to return a copy of `audioRecordData`.
- Modified `removeData` in `AudioHelper` to remove all data.
- Modified `uploadLastData` in `AudioHelper` to remove data after clipping.
- Removed unused parameter `audioDataList` from `generateAudioFileFromAudioData` in `UploadService`.
- Removed unused parameters from `generateAudioFileFromAudioData` in `UploadService`.
- Modified `generateAudioFileFromAudioData` in `UploadService` to use indices for calculations.
- Modified `generateAudioFileFromAudioData` in `UploadService` to check for audio length.
- Modified `UploadService` to add start and end times to `onNewFileCreated` call.