### PR TITLE
Test: Add unit tests for AudioHelper, UploadService, and AudioCombiner

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+mockito = "5.4.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
 composeBom = "2023.08.00"
@@ -60,6 +61,8 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 ok2curl = { module = "com.github.mrmike:ok2curl", version.ref = "ok2curl" }
 brotili = { module = "org.brotli:dec", version.ref = "brotiliVersion" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/voice2rx_sdk/build.gradle.kts
+++ b/voice2rx_sdk/build.gradle.kts
@@ -105,6 +105,8 @@ afterEvaluate {
 
 dependencies {
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
     androidTestImplementation(libs.ext.junit)
     api(libs.silero)
     implementation(libs.aws.android.sdk.s3)

--- a/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/AudioCombinerTest.kt
+++ b/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/AudioCombinerTest.kt
@@ -1,0 +1,210 @@
+package com.eka.voice2rx_sdk
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class AudioCombinerTest {
+
+    @Mock
+    private lateinit var context: Context
+
+    private lateinit var audioCombiner: AudioCombiner
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        audioCombiner = AudioCombiner()
+    }
+
+    @Test
+    fun `createWavHeader should generate correct WAV header`() {
+        val dataSize = 1000
+        val sampleRate = 16000
+
+        val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+        assertEquals(44, header.size)
+
+        // Check RIFF signature
+        assertEquals("RIFF", String(header, 0, 4))
+
+        // Check WAVE signature
+        assertEquals("WAVE", String(header, 8, 4))
+
+        // Check fmt signature
+        assertEquals("fmt ", String(header, 12, 4))
+
+        // Check data signature
+        assertEquals("data", String(header, 36, 4))
+    }
+
+    @Test
+    fun `createWavHeader should handle different sample rates`() {
+        val dataSize = 2000
+        val sampleRate1 = 8000
+        val sampleRate2 = 44100
+
+        val header1 = audioCombiner.createWavHeader(dataSize, sampleRate1)
+        val header2 = audioCombiner.createWavHeader(dataSize, sampleRate2)
+
+        assertEquals(44, header1.size)
+        assertEquals(44, header2.size)
+
+        // Both should be valid WAV headers
+        assertEquals("RIFF", String(header1, 0, 4))
+        assertEquals("RIFF", String(header2, 0, 4))
+    }
+
+    @Test
+    fun `createWavHeader should handle zero data size`() {
+        val header = audioCombiner.createWavHeader(0, 16000)
+
+        assertEquals(44, header.size)
+        assertEquals("RIFF", String(header, 0, 4))
+        assertEquals("WAVE", String(header, 8, 4))
+    }
+
+    @Test
+    fun `createWavHeader should have correct structure`() {
+        val dataSize = 4000
+        val sampleRate = 16000
+        val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+        val buffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+
+        // Skip RIFF
+        buffer.position(4)
+        val totalDataLen = buffer.int
+        assertEquals(dataSize + 36, totalDataLen)
+
+        // Skip WAVE and fmt
+        buffer.position(20)
+        val subChunkSize = buffer.int
+        assertEquals(16, subChunkSize)
+
+        val audioFormat = buffer.short
+        assertEquals(1, audioFormat.toInt()) // PCM
+
+        val channels = buffer.short
+        assertEquals(1, channels.toInt()) // Mono
+
+        val sampleRateFromHeader = buffer.int
+        assertEquals(sampleRate, sampleRateFromHeader)
+
+        val blockAlign = buffer.short
+        assertEquals(2, blockAlign.toInt()) // 16-bit mono
+
+        val bitsPerSample = buffer.short
+        assertEquals(16, bitsPerSample.toInt())
+    }
+
+    @Test
+    fun `createWavHeader should calculate byte rate correctly`() {
+        val dataSize = 1000
+        val sampleRate = 16000
+        val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+        val buffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.position(28) // Position to byte rate field
+
+        val byteRate = buffer.int
+        val expectedByteRate = sampleRate * 2 // 16-bit mono
+        assertEquals(expectedByteRate, byteRate)
+    }
+
+    @Test
+    fun `createWavHeader should handle large data sizes`() {
+        val dataSize = Int.MAX_VALUE / 2
+        val sampleRate = 44100
+
+        val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+        assertEquals(44, header.size)
+        assertEquals("RIFF", String(header, 0, 4))
+        assertEquals("WAVE", String(header, 8, 4))
+        assertEquals("fmt ", String(header, 12, 4))
+        assertEquals("data", String(header, 36, 4))
+    }
+
+    @Test
+    fun `createWavHeader should handle minimum values`() {
+        val dataSize = 1
+        val sampleRate = 8000
+
+        val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+        assertEquals(44, header.size)
+
+        val buffer = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.position(4)
+        val totalDataLen = buffer.int
+        assertEquals(37, totalDataLen) // dataSize(1) + 36
+    }
+
+    @Test
+    fun `createWavHeader should maintain consistent format`() {
+        val testCases = listOf(
+            Pair(100, 8000),
+            Pair(1000, 16000),
+            Pair(10000, 22050),
+            Pair(100000, 44100),
+            Pair(1000000, 48000)
+        )
+
+        testCases.forEach { (dataSize, sampleRate) ->
+            val header = audioCombiner.createWavHeader(dataSize, sampleRate)
+
+            assertEquals("Header size should be 44 bytes", 44, header.size)
+            assertEquals("RIFF signature", "RIFF", String(header, 0, 4))
+            assertEquals("WAVE signature", "WAVE", String(header, 8, 4))
+            assertEquals("fmt signature", "fmt ", String(header, 12, 4))
+            assertEquals("data signature", "data", String(header, 36, 4))
+        }
+    }
+
+    @Test
+    fun `stopPlaying should execute without exceptions`() {
+        // Since stopPlaying() works with private fields and MediaPlayer instances,
+        // we can at least verify the method doesn't throw exceptions
+        try {
+            audioCombiner.stopPlaying()
+            // Test passes if no exception is thrown
+            assertTrue(true)
+        } catch (e: Exception) {
+            fail("stopPlaying() should not throw exceptions: ${e.message}")
+        }
+    }
+
+    @Test
+    fun `audioCombiner should be instantiable`() {
+        val newAudioCombiner = AudioCombiner()
+        assertNotNull(newAudioCombiner)
+    }
+
+    @Test
+    fun `createWavHeader should produce different headers for different inputs`() {
+        val header1 = audioCombiner.createWavHeader(1000, 16000)
+        val header2 = audioCombiner.createWavHeader(2000, 16000)
+        val header3 = audioCombiner.createWavHeader(1000, 22050)
+
+        // Headers should be different when parameters change
+        assertFalse(
+            "Headers with different data sizes should differ",
+            header1.contentEquals(header2)
+        )
+        assertFalse(
+            "Headers with different sample rates should differ",
+            header1.contentEquals(header3)
+        )
+    }
+}

--- a/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/AudioHelperTest.kt
+++ b/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/AudioHelperTest.kt
@@ -1,0 +1,327 @@
+package com.eka.voice2rx_sdk
+
+import android.content.Context
+import com.eka.voice2rx_sdk.data.local.models.FileInfo
+import com.eka.voice2rx_sdk.data.local.models.IncludeStatus
+import com.eka.voice2rx_sdk.sdkinit.V2RxInternal
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.util.Locale
+
+class AudioHelperTest {
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var viewModel: V2RxInternal
+
+    @Mock
+    private lateinit var uploadService: UploadService
+
+    @Mock
+    private lateinit var filesDir: File
+
+    private lateinit var audioHelper: AudioHelper
+    private val sessionId = "test_session_123"
+    private val sampleRate = 16000
+    private val frameSize = 512
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(viewModel.getUploadService()).thenReturn(uploadService)
+        whenever(context.filesDir).thenReturn(filesDir)
+
+        audioHelper = AudioHelper(
+            context = context,
+            viewModel = viewModel,
+            sessionId = sessionId,
+            prefLength = 10,
+            despLength = 20,
+            maxLength = 25,
+            sampleRate = sampleRate,
+            frameSize = frameSize
+        )
+    }
+
+    @Test
+    fun `process should handle silence frames correctly`() {
+        val silenceFrame = AudioRecordModel(
+            frameData = shortArrayOf(0, 0, 0, 0),
+            isSilence = true,
+            isClipped = false,
+            timeStamp = 100L
+        )
+
+        audioHelper.process(silenceFrame)
+
+        assertFalse(audioHelper.isClipping())
+        assertEquals(1, audioHelper.getAudioRecordData().size)
+        assertFalse(audioHelper.getAudioRecordData()[0].isClipped)
+    }
+
+    @Test
+    fun `process should handle non-silence frames correctly`() {
+        val nonSilenceFrame = AudioRecordModel(
+            frameData = shortArrayOf(100, 200, 300, 400),
+            isSilence = false,
+            isClipped = false,
+            timeStamp = 100L
+        )
+
+        audioHelper.process(nonSilenceFrame)
+
+        assertFalse(audioHelper.isClipping())
+        assertEquals(1, audioHelper.getAudioRecordData().size)
+        assertFalse(audioHelper.getAudioRecordData()[0].isClipped)
+    }
+
+    @Test
+    fun `getClipTimeFromClipIndex should return correct time format`() {
+        val time1 = audioHelper.getClipTimeFromClipIndex(0)
+        assertEquals("00.0000", time1)
+
+        val time2 = audioHelper.getClipTimeFromClipIndex(100)
+        val expectedTime = (100.0 * frameSize) / sampleRate
+        assertEquals(String.format(Locale.ENGLISH, "%.4f", expectedTime), time2)
+    }
+
+    @Test
+    fun `getClipTimeFromClipIndex should handle negative indices`() {
+        val time = audioHelper.getClipTimeFromClipIndex(-1)
+        assertEquals("00.0000", time)
+    }
+
+    @Test
+    fun `removeData should reset clipping state`() {
+        audioHelper.removeData()
+
+        assertFalse(audioHelper.isClipping())
+    }
+
+    @Test
+    fun `getAudioRecordData should return copy of data`() {
+        val frame1 = AudioRecordModel(shortArrayOf(1, 2), false, false, 100L)
+        val frame2 = AudioRecordModel(shortArrayOf(3, 4), true, false, 200L)
+
+        audioHelper.process(frame1)
+        audioHelper.process(frame2)
+
+        val data = audioHelper.getAudioRecordData()
+        assertEquals(2, data.size)
+        assertEquals(100L, data[0].timeStamp)
+        assertEquals(200L, data[1].timeStamp)
+    }
+
+    @Test
+    fun `uploadLastData should trigger upload with correct parameters`() {
+        val frame1 = AudioRecordModel(shortArrayOf(1, 2), false, false, 100L)
+        val frame2 = AudioRecordModel(shortArrayOf(3, 4), false, false, 200L)
+
+        audioHelper.process(frame1)
+        audioHelper.process(frame2)
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+        audioHelper.uploadLastData(callback)
+
+        verify(uploadService).processAndUpload(any(), eq(1), eq(callback))
+        assertTrue(audioHelper.isClipping())
+    }
+
+    @Test
+    fun `getCombinedAudio should combine audio chunks correctly`() {
+        val chunk1 = shortArrayOf(1, 2, 3)
+        val chunk2 = shortArrayOf(4, 5, 6)
+        val chunk3 = shortArrayOf(7, 8)
+        val audioChunks = arrayListOf(chunk1, chunk2, chunk3)
+
+        val result = audioHelper.getCombinedAudio(audioChunks)
+
+        val expected = shortArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        assertArrayEquals(expected, result)
+    }
+
+    @Test
+    fun `getCombinedAudio should handle empty chunks`() {
+        val audioChunks = arrayListOf<ShortArray>()
+
+        val result = audioHelper.getCombinedAudio(audioChunks)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `onNewFileCreated should call viewModel addValueToChunksInfo`() {
+        audioHelper.onNewFileCreated("test_file.m4a", "2.5000", "0.0000")
+
+        verify(viewModel).addValueToChunksInfo(
+            "test_file.m4a",
+            FileInfo(st = "0.0000", et = "2.5000")
+        )
+    }
+
+    @Test
+    fun `process should handle different sample rates and frame sizes correctly`() {
+        val customAudioHelper = AudioHelper(
+            context = context,
+            viewModel = viewModel,
+            sessionId = sessionId,
+            prefLength = 5,
+            despLength = 10,
+            maxLength = 15,
+            sampleRate = 8000,
+            frameSize = 256
+        )
+
+        val frame = AudioRecordModel(
+            frameData = shortArrayOf(1, 2, 3, 4),
+            isSilence = false,
+            isClipped = false,
+            timeStamp = 100L
+        )
+
+        customAudioHelper.process(frame)
+
+        assertEquals(1, customAudioHelper.getAudioRecordData().size)
+        assertFalse(customAudioHelper.isClipping())
+    }
+
+    @Test
+    fun `process should accumulate silence duration correctly`() {
+        // Process multiple silence frames
+        repeat(5) {
+            val silenceFrame = AudioRecordModel(
+                frameData = shortArrayOf(0, 0, 0, 0),
+                isSilence = true,
+                isClipped = false,
+                timeStamp = it * 100L
+            )
+            audioHelper.process(silenceFrame)
+        }
+
+        assertEquals(5, audioHelper.getAudioRecordData().size)
+        audioHelper.getAudioRecordData().forEach { frame ->
+            assertFalse(frame.isClipped)
+        }
+    }
+
+    @Test
+    fun `process should reset silence duration on non-silence`() {
+        // Process silence frame
+        val silenceFrame = AudioRecordModel(
+            frameData = shortArrayOf(0, 0, 0, 0),
+            isSilence = true,
+            isClipped = false,
+            timeStamp = 100L
+        )
+        audioHelper.process(silenceFrame)
+
+        // Process non-silence frame (should reset silence duration)
+        val nonSilenceFrame = AudioRecordModel(
+            frameData = shortArrayOf(100, 200, 300, 400),
+            isSilence = false,
+            isClipped = false,
+            timeStamp = 200L
+        )
+        audioHelper.process(nonSilenceFrame)
+
+        assertEquals(2, audioHelper.getAudioRecordData().size)
+        assertFalse(audioHelper.getAudioRecordData()[0].isClipped)
+        assertFalse(audioHelper.getAudioRecordData()[1].isClipped)
+    }
+
+    @Test
+    fun `getClipTimeFromClipIndex should handle various indices`() {
+        val testCases = listOf(
+            Pair(0, "00.0000"),
+            Pair(1, String.format(Locale.ENGLISH, "%.4f", 1.0 * frameSize / sampleRate)),
+            Pair(10, String.format(Locale.ENGLISH, "%.4f", 10.0 * frameSize / sampleRate)),
+            Pair(100, String.format(Locale.ENGLISH, "%.4f", 100.0 * frameSize / sampleRate))
+        )
+
+        testCases.forEach { (index, expected) ->
+            val result = audioHelper.getClipTimeFromClipIndex(index)
+            assertEquals("Index $index should produce time $expected", expected, result)
+        }
+    }
+
+    @Test
+    fun `uploadLastData should update clip indices correctly`() {
+        // Add some frames
+        repeat(3) {
+            val frame = AudioRecordModel(shortArrayOf(it.toShort()), false, false, it * 100L)
+            audioHelper.process(frame)
+        }
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+        audioHelper.uploadLastData(callback)
+
+        // Verify that upload service is called with correct parameters
+        verify(uploadService).processAndUpload(eq(0), eq(2), eq(callback))
+        assertTrue(audioHelper.isClipping())
+    }
+
+    @Test
+    fun `getCombinedAudio should preserve original data integrity`() {
+        val chunk1 = shortArrayOf(Short.MAX_VALUE, Short.MIN_VALUE)
+        val chunk2 = shortArrayOf(0, -1, 1)
+        val audioChunks = arrayListOf(chunk1, chunk2)
+
+        val result = audioHelper.getCombinedAudio(audioChunks)
+
+        assertEquals(5, result.size)
+        assertEquals(Short.MAX_VALUE, result[0])
+        assertEquals(Short.MIN_VALUE, result[1])
+        assertEquals(0, result[2])
+        assertEquals(-1, result[3])
+        assertEquals(1, result[4])
+    }
+
+    @Test
+    fun `process should maintain frame order`() {
+        val frames = listOf(
+            AudioRecordModel(shortArrayOf(1), false, false, 100L),
+            AudioRecordModel(shortArrayOf(2), true, false, 200L),
+            AudioRecordModel(shortArrayOf(3), false, false, 300L)
+        )
+
+        frames.forEach { audioHelper.process(it) }
+
+        val data = audioHelper.getAudioRecordData()
+        assertEquals(3, data.size)
+        assertEquals(100L, data[0].timeStamp)
+        assertEquals(200L, data[1].timeStamp)
+        assertEquals(300L, data[2].timeStamp)
+        assertEquals(1, data[0].frameData[0])
+        assertEquals(2, data[1].frameData[0])
+        assertEquals(3, data[2].frameData[0])
+    }
+
+    @Test
+    fun `removeData should preserve current clip index`() {
+        // Add some frames to establish indices
+        repeat(5) {
+            val frame = AudioRecordModel(shortArrayOf(it.toShort()), false, false, it * 100L)
+            audioHelper.process(frame)
+        }
+
+        audioHelper.removeData()
+
+        assertFalse(audioHelper.isClipping())
+        // Data should still be there, just clipping state reset
+        assertEquals(5, audioHelper.getAudioRecordData().size)
+    }
+}

--- a/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/UploadServiceTest.kt
+++ b/voice2rx_sdk/src/test/java/com/eka/voice2rx_sdk/UploadServiceTest.kt
@@ -1,0 +1,238 @@
+package com.eka.voice2rx_sdk
+
+import android.content.Context
+import com.eka.voice2rx_sdk.data.local.models.FileInfo
+import com.eka.voice2rx_sdk.data.local.models.IncludeStatus
+import com.eka.voice2rx_sdk.sdkinit.V2RxInternal
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.io.File
+
+class UploadServiceTest {
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var audioHelper: AudioHelper
+
+    @Mock
+    private lateinit var v2RxInternal: V2RxInternal
+
+    @Mock
+    private lateinit var filesDir: File
+
+    private lateinit var uploadService: UploadService
+    private val sessionId = "test_session_123"
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(context.filesDir).thenReturn(filesDir)
+        uploadService = UploadService(context, audioHelper, sessionId, v2RxInternal)
+    }
+
+    @Test
+    fun `processAndUpload should return early when not clipping`() {
+        whenever(audioHelper.isClipping()).thenReturn(false)
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+        uploadService.processAndUpload(0, 5, callback)
+
+        verify(audioHelper, never()).getAudioRecordData()
+        verifyNoInteractions(callback)
+    }
+
+    @Test
+    fun `processAndUpload should process audio data when clipping`() {
+        val mockAudioData = listOf(
+            AudioRecordModel(shortArrayOf(1, 2, 3), false, false, 100L),
+            AudioRecordModel(shortArrayOf(4, 5, 6), false, false, 200L),
+            AudioRecordModel(shortArrayOf(7, 8, 9), false, false, 300L)
+        )
+
+        whenever(audioHelper.isClipping()).thenReturn(true)
+        whenever(audioHelper.getAudioRecordData()).thenReturn(mockAudioData)
+        whenever(audioHelper.getClipTimeFromClipIndex(any())).thenReturn("1.0000")
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        uploadService.processAndUpload(0, 2, callback)
+
+        verify(audioHelper).getAudioRecordData()
+        verify(audioHelper).removeData()
+    }
+
+    @Test
+    fun `getCombinedAudio should combine audio chunks correctly`() {
+        val chunk1 = shortArrayOf(1, 2, 3)
+        val chunk2 = shortArrayOf(4, 5, 6)
+        val chunk3 = shortArrayOf(7, 8)
+        val audioChunks = arrayListOf(chunk1, chunk2, chunk3)
+
+        val result = uploadService.getCombinedAudio(audioChunks)
+
+        val expected = shortArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+        assertArrayEquals(expected, result)
+        assertEquals(8, result.size)
+    }
+
+    @Test
+    fun `getCombinedAudio should return empty array for empty chunks`() {
+        val audioChunks = arrayListOf<ShortArray>()
+
+        val result = uploadService.getCombinedAudio(audioChunks)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `getCombinedAudio should handle single chunk`() {
+        val chunk = shortArrayOf(1, 2, 3, 4, 5)
+        val audioChunks = arrayListOf(chunk)
+
+        val result = uploadService.getCombinedAudio(audioChunks)
+
+        assertArrayEquals(chunk, result)
+        assertEquals(5, result.size)
+    }
+
+    @Test
+    fun `generateAudioFileFromAudioData should not include file when audio data is too small`() {
+        val smallAudioData = ShortArray(15000) // Less than 16000 threshold
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        uploadService.generateAudioFileFromAudioData(smallAudioData, 0, 5, callback)
+
+        verify(callback).invoke("", FileInfo(st = null, et = null), IncludeStatus.NOT_INCLUDED)
+        verify(v2RxInternal, never()).onNewFileCreated(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `generateAudioFileFromAudioData should process valid audio data`() {
+        val validAudioData = ShortArray(20000) // Above 16000 threshold
+        whenever(audioHelper.getClipTimeFromClipIndex(0)).thenReturn("0.0000")
+        whenever(audioHelper.getClipTimeFromClipIndex(5)).thenReturn("2.5000")
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        uploadService.generateAudioFileFromAudioData(validAudioData, 0, 5, callback)
+
+        verify(callback).invoke(
+            argThat { this.contains("test_session_123_1.m4a") },
+            any(),
+            eq(IncludeStatus.INCLUDED)
+        )
+        verify(audioHelper).onNewFileCreated(any(), eq("2.5000"), eq("0.0000"))
+        verify(v2RxInternal).onNewFileCreated(
+            any(),
+            any(),
+            any(),
+            any(),
+            FileInfo(st = "0.0000", et = "2.5000")
+        )
+    }
+
+    @Test
+    fun `processAndUpload should handle exceptions gracefully`() {
+        whenever(audioHelper.isClipping()).thenReturn(true)
+        whenever(audioHelper.getAudioRecordData()).thenThrow(RuntimeException("Test exception"))
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        // Should not throw exception
+        uploadService.processAndUpload(0, 5, callback)
+
+        verifyNoInteractions(callback)
+    }
+
+    @Test
+    fun `processAndUpload should handle invalid clip indices`() {
+        val mockAudioData = listOf(
+            AudioRecordModel(shortArrayOf(1, 2, 3), false, false, 100L)
+        )
+
+        whenever(audioHelper.isClipping()).thenReturn(true)
+        whenever(audioHelper.getAudioRecordData()).thenReturn(mockAudioData)
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        // Test with clipIndex = -1
+        uploadService.processAndUpload(0, -1, callback)
+
+        verifyNoInteractions(callback)
+        verify(audioHelper).removeData()
+    }
+
+    @Test
+    fun `getCombinedAudio should handle chunks with different sizes`() {
+        val chunk1 = shortArrayOf(1)
+        val chunk2 = shortArrayOf(2, 3, 4, 5)
+        val chunk3 = shortArrayOf(6, 7)
+        val audioChunks = arrayListOf(chunk1, chunk2, chunk3)
+
+        val result = uploadService.getCombinedAudio(audioChunks)
+
+        val expected = shortArrayOf(1, 2, 3, 4, 5, 6, 7)
+        assertArrayEquals(expected, result)
+        assertEquals(7, result.size)
+    }
+
+    @Test
+    fun `getCombinedAudio should preserve audio data integrity`() {
+        val originalData1 = shortArrayOf(100, -100, 200, -200)
+        val originalData2 = shortArrayOf(300, -300, 400, -400)
+        val audioChunks = arrayListOf(originalData1, originalData2)
+
+        val result = uploadService.getCombinedAudio(audioChunks)
+
+        assertEquals(8, result.size)
+        assertEquals(100, result[0])
+        assertEquals(-100, result[1])
+        assertEquals(200, result[2])
+        assertEquals(-200, result[3])
+        assertEquals(300, result[4])
+        assertEquals(-300, result[5])
+        assertEquals(400, result[6])
+        assertEquals(-400, result[7])
+    }
+
+    @Test
+    fun `generateAudioFileFromAudioData should increment file index`() {
+        val validAudioData1 = ShortArray(20000)
+        val validAudioData2 = ShortArray(25000)
+
+        whenever(audioHelper.getClipTimeFromClipIndex(any())).thenReturn("1.0000")
+
+        val callback = mock<(String, FileInfo, IncludeStatus) -> Unit>()
+
+        // First call
+        uploadService.generateAudioFileFromAudioData(validAudioData1, 0, 5, callback)
+
+        // Second call
+        uploadService.generateAudioFileFromAudioData(validAudioData2, 5, 10, callback)
+
+        verify(callback).invoke(
+            argThat { this.contains("test_session_123_1.m4a") },
+            any(),
+            any()
+        )
+        verify(callback).invoke(
+            argThat { this.contains("test_session_123_2.m4a") },
+            any(),
+            any()
+        )
+    }
+}


### PR DESCRIPTION
This commit introduces unit tests for the following classes:
- `AudioHelper`: Tests cover processing of silence/non-silence frames, clip time calculation, data removal, audio combination, and interaction with `V2RxInternal`.
- `UploadService`: Tests verify audio processing logic, file generation based on audio data size, interaction with `AudioHelper` and `V2RxInternal`, and correct handling of clip indices.
- `AudioCombiner`: Tests focus on the `createWavHeader` method, ensuring correct WAV header generation for various data sizes and sample rates, and verify `stopPlaying` can be called without exceptions.

The tests utilize Mockito for mocking dependencies.

Additionally, Mockito dependencies have been added to the `build.gradle.kts` file and `libs.versions.toml`.