### PR TITLE
build: update ekaNetworkAndroid to 2.0.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.12.3"
-ekaNetworkAndroid = "2.0.5"
+ekaNetworkAndroid = "2.0.6"
 #ekaNetworkAndroid = "2.0.0"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"


### PR DESCRIPTION
This commit updates the `ekaNetworkAndroid` library version from `2.0.5` to `2.0.6` in the version catalog.